### PR TITLE
feat: add time-of-day shifting UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -204,15 +204,21 @@ select {
 }
 
 .surface-card {
-  background: linear-gradient(
-    180deg,
-    rgba(255, 255, 255, 0.9) 0%,
-    rgba(241, 246, 255, 0.94) 100%
+  background: var(
+    --time-card-bg,
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.9) 0%,
+      rgba(241, 246, 255, 0.94) 100%
+    )
   );
-  border: 1px solid rgba(196, 220, 255, 0.72);
+  border: 1px solid var(--time-card-border, rgba(196, 220, 255, 0.72));
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-card);
   backdrop-filter: blur(14px);
+  transition:
+    background 1.8s ease,
+    border-color 1.8s ease;
 }
 
 .control-pill {
@@ -261,6 +267,257 @@ select {
 
 .animate-blob-morph {
   animation: blobMorph 18s ease-in-out infinite;
+}
+
+/* ── Time-of-day keyframes ── */
+
+@keyframes twinkle {
+  0%,
+  100% {
+    opacity: 0.2;
+    transform: scale(0.8);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1.2);
+  }
+}
+
+@keyframes dawnGlow {
+  0%,
+  100% {
+    opacity: 0.3;
+    filter: blur(60px);
+  }
+
+  50% {
+    opacity: 0.6;
+    filter: blur(80px);
+  }
+}
+
+/* ── Time-of-day theme overrides ── */
+
+html[data-time="dawn"] {
+  --time-surface: #fff7ed;
+  --time-gradient: linear-gradient(
+    135deg,
+    #fef3c7 0%,
+    #fde68a 25%,
+    #fed7aa 50%,
+    #fdba74 75%,
+    #fef3c7 100%
+  );
+  --time-text: #78350f;
+  --time-text-muted: #92400e;
+  --time-glow: rgba(251, 191, 36, 0.25);
+  --time-orb-1: #fbbf24;
+  --time-orb-2: #f97316;
+  --time-orb-3: #fcd34d;
+  --time-card-bg: linear-gradient(
+    180deg,
+    rgba(255, 251, 235, 0.92) 0%,
+    rgba(254, 243, 199, 0.95) 100%
+  );
+  --time-card-border: rgba(251, 191, 36, 0.4);
+  --time-header-bg: rgba(255, 251, 235, 0.55);
+  --time-footer-bg: linear-gradient(
+    to right,
+    rgba(255, 251, 235, 0.8),
+    rgba(254, 243, 199, 0.85)
+  );
+  --time-blob-1: #fbbf24;
+  --time-blob-2: #f97316;
+  --time-blob-3: #fcd34d;
+}
+
+html[data-time="day"] {
+  --time-surface: #f9fbff;
+  --time-gradient: linear-gradient(
+    135deg,
+    #f5f3ff 0%,
+    #ede9fe 25%,
+    #ddd6fe 50%,
+    #c4b5fd 75%,
+    #ede7fe 100%
+  );
+  --time-text: #12314f;
+  --time-text-muted: #2a5374;
+  --time-glow: rgba(56, 189, 248, 0.25);
+  --time-orb-1: #9eceff;
+  --time-orb-2: #6dd5ed;
+  --time-orb-3: #38bdf8;
+  --time-card-bg: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.9) 0%,
+    rgba(241, 246, 255, 0.94) 100%
+  );
+  --time-card-border: rgba(196, 220, 255, 0.72);
+  --time-header-bg: rgba(255, 255, 255, 0.32);
+  --time-footer-bg: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0.75),
+    rgba(224, 242, 254, 0.8)
+  );
+  --time-blob-1: #9eceff;
+  --time-blob-2: #6dd5ed;
+  --time-blob-3: #38bdf8;
+}
+
+html[data-time="dusk"] {
+  --time-surface: #1e1b4b;
+  --time-gradient: linear-gradient(
+    135deg,
+    #1e1b4b 0%,
+    #312e81 25%,
+    #4c1d95 50%,
+    #581c87 75%,
+    #1e1b4b 100%
+  );
+  --time-text: #e0e7ff;
+  --time-text-muted: #a5b4fc;
+  --time-glow: rgba(139, 92, 246, 0.35);
+  --time-orb-1: #8b5cf6;
+  --time-orb-2: #a78bfa;
+  --time-orb-3: #c084fc;
+  --time-card-bg: linear-gradient(
+    180deg,
+    rgba(30, 27, 75, 0.88) 0%,
+    rgba(49, 46, 129, 0.92) 100%
+  );
+  --time-card-border: rgba(139, 92, 246, 0.4);
+  --time-header-bg: rgba(30, 27, 75, 0.6);
+  --time-footer-bg: linear-gradient(
+    to right,
+    rgba(30, 27, 75, 0.8),
+    rgba(49, 46, 129, 0.85)
+  );
+  --time-blob-1: #8b5cf6;
+  --time-blob-2: #a78bfa;
+  --time-blob-3: #c084fc;
+}
+
+html[data-time="night"] {
+  --time-surface: #0c0a1d;
+  --time-gradient: linear-gradient(
+    135deg,
+    #0c0a1d 0%,
+    #0f172a 25%,
+    #1e1b4b 50%,
+    #0f172a 75%,
+    #0c0a1d 100%
+  );
+  --time-text: #e2e8f0;
+  --time-text-muted: #94a3b8;
+  --time-glow: rgba(56, 189, 248, 0.15);
+  --time-orb-1: #1e3a5f;
+  --time-orb-2: #1e40af;
+  --time-orb-3: #312e81;
+  --time-card-bg: linear-gradient(
+    180deg,
+    rgba(15, 23, 42, 0.85) 0%,
+    rgba(30, 27, 75, 0.9) 100%
+  );
+  --time-card-border: rgba(56, 189, 248, 0.2);
+  --time-header-bg: rgba(15, 23, 42, 0.65);
+  --time-footer-bg: linear-gradient(
+    to right,
+    rgba(15, 23, 42, 0.8),
+    rgba(30, 27, 75, 0.85)
+  );
+  --time-blob-1: #1e3a5f;
+  --time-blob-2: #1e40af;
+  --time-blob-3: #312e81;
+}
+
+/* ── Time-aware surface classes ── */
+
+.time-body {
+  background-color: var(--time-surface);
+  color: var(--time-text);
+  transition:
+    background-color 1.8s ease,
+    color 1.8s ease;
+}
+
+.time-gradient {
+  background: var(--time-gradient);
+  transition: background 1.8s ease;
+}
+
+.time-surface-card {
+  background: var(--time-card-bg);
+  border-color: var(--time-card-border);
+  transition:
+    background 1.8s ease,
+    border-color 1.8s ease;
+}
+
+.time-header {
+  background: var(--time-header-bg);
+  backdrop-filter: blur(16px);
+  transition: background 1.8s ease;
+}
+
+.time-footer {
+  background: var(--time-footer-bg);
+  transition: background 1.8s ease;
+}
+
+/* ── Night stars layer ── */
+
+.time-stars {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 2s ease;
+}
+
+html[data-time="night"] .time-stars {
+  opacity: 1;
+}
+
+.time-star {
+  position: absolute;
+  width: 2px;
+  height: 2px;
+  background: #e2e8f0;
+  border-radius: 50%;
+  animation: twinkle var(--tw-duration, 3s) ease-in-out infinite;
+  animation-delay: var(--tw-delay, 0s);
+}
+
+/* ── Dawn glow overlay ── */
+
+.time-dawn-glow {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 2s ease;
+}
+
+html[data-time="dawn"] .time-dawn-glow {
+  opacity: 1;
+}
+
+.time-dawn-glow::before {
+  content: "";
+  position: absolute;
+  bottom: -20%;
+  left: 10%;
+  width: 80%;
+  height: 60%;
+  background: radial-gradient(
+    ellipse at center,
+    rgba(251, 191, 36, 0.35) 0%,
+    rgba(249, 115, 22, 0.15) 40%,
+    transparent 70%
+  );
+  animation: dawnGlow 6s ease-in-out infinite;
 }
 
 .sr-only {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import EasterEggKeyboardListener from "@/components/EasterEggKeyboardListener";
 import SurrealistBackground from "@/components/SurrealistBackground";
 import { QualityProvider } from "@/context/QualityContext";
+import { TimeShiftProvider } from "@/context/TimeShiftContext";
 import Footer from "@/sections/Footer";
 import Header from "@/sections/Header";
 
@@ -29,20 +30,22 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="es">
+    <html lang="es" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} time-body antialiased`}
       >
         <QualityProvider>
-          <div className="relative isolate min-h-screen overflow-hidden bg-surreal-gradient">
-            <SurrealistBackground />
-            <div className="relative z-10 flex min-h-screen flex-col">
-              <Header />
-              {children}
-              <Footer />
+          <TimeShiftProvider>
+            <div className="time-gradient relative isolate min-h-screen overflow-hidden">
+              <SurrealistBackground />
+              <div className="relative z-10 flex min-h-screen flex-col">
+                <Header />
+                {children}
+                <Footer />
+              </div>
             </div>
-          </div>
-          <EasterEggKeyboardListener />
+            <EasterEggKeyboardListener />
+          </TimeShiftProvider>
         </QualityProvider>
       </body>
     </html>

--- a/src/components/QualityCard.tsx
+++ b/src/components/QualityCard.tsx
@@ -4,6 +4,7 @@ import { motion } from "framer-motion";
 import { Heart, Star } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
+import { useTimeShift } from "@/context/TimeShiftContext";
 import { isLandaBirthdayWeek } from "@/utils/dateFormatter";
 import {
   birthdayColorCombo,
@@ -18,6 +19,7 @@ interface QualityCardProps {
 
 const QualityCard: React.FC<QualityCardProps> = ({ entry, onSecretClick }) => {
   const [isHovered, setIsHovered] = useState(false);
+  const { period } = useTimeShift();
 
   // Check if this is Landa's birthday week
   const isBirthdayWeek = isLandaBirthdayWeek(entry.week, entry.year);
@@ -83,6 +85,15 @@ const QualityCard: React.FC<QualityCardProps> = ({ entry, onSecretClick }) => {
     });
   };
 
+  const glowColor =
+    period === "night"
+      ? "var(--time-glow)"
+      : period === "dawn"
+        ? "rgba(251, 191, 36, 0.25)"
+        : period === "dusk"
+          ? "rgba(139, 92, 246, 0.3)"
+          : "rgba(56, 189, 248, 0.33)";
+
   return (
     <motion.div
       className={`relative flex w-full flex-col items-center justify-center overflow-hidden border-2 px-2 transition-all duration-500 animate-blob-morph
@@ -95,8 +106,8 @@ const QualityCard: React.FC<QualityCardProps> = ({ entry, onSecretClick }) => {
       style={{
         minHeight: "320px",
         boxShadow: isBirthdayWeek
-          ? "0 0 52px 0 #f8717130, 0 14px 34px -18px #fbbf2455"
-          : "0 0 52px 0 #a78bfa24, 0 14px 34px -18px #38bdf855",
+          ? `0 0 52px 0 #f8717130, 0 14px 34px -18px #fbbf2455`
+          : `0 0 60px 0 ${glowColor}, 0 14px 34px -18px ${glowColor}`,
       }}
       role="article"
       aria-label={`Mensaje de la semana ${entry.week} del ${entry.year}`}

--- a/src/components/SurrealistBackground.tsx
+++ b/src/components/SurrealistBackground.tsx
@@ -1,17 +1,96 @@
+"use client";
+
 import Image from "next/image";
+import { useMemo } from "react";
+import { useTimeShift } from "@/context/TimeShiftContext";
+
+const ORB_CONFIGS = {
+  dawn: {
+    orb1: "bg-amber-300",
+    orb2: "bg-orange-400",
+    orb3: "bg-yellow-300",
+    imageBlend: "mix-blend-soft-light",
+    imageOpacity: "opacity-20 sm:opacity-25",
+    orbOpacity: "opacity-30 sm:opacity-40",
+  },
+  day: {
+    orb1: "bg-dream-200",
+    orb2: "bg-dream-300",
+    orb3: "bg-dream-400",
+    imageBlend: "mix-blend-multiply",
+    imageOpacity: "opacity-14 sm:opacity-20",
+    orbOpacity: "opacity-24 sm:opacity-30",
+  },
+  dusk: {
+    orb1: "bg-violet-500",
+    orb2: "bg-purple-400",
+    orb3: "bg-fuchsia-400",
+    imageBlend: "mix-blend-soft-light",
+    imageOpacity: "opacity-10 sm:opacity-16",
+    orbOpacity: "opacity-28 sm:opacity-35",
+  },
+  night: {
+    orb1: "bg-blue-900",
+    orb2: "bg-indigo-800",
+    orb3: "bg-violet-900",
+    imageBlend: "mix-blend-soft-light",
+    imageOpacity: "opacity-6 sm:opacity-10",
+    orbOpacity: "opacity-20 sm:opacity-25",
+  },
+} as const;
+
+function generateStars(count: number) {
+  const stars = [];
+  for (let i = 0; i < count; i++) {
+    const x = Math.round(Math.random() * 100);
+    const y = Math.round(Math.random() * 100);
+    const duration = 2 + Math.round(Math.random() * 4);
+    const delay = Math.round(Math.random() * 5);
+    stars.push({ x, y, duration, delay, id: i });
+  }
+  return stars;
+}
 
 export default function SurrealistBackground() {
+  const { period } = useTimeShift();
+  const config = ORB_CONFIGS[period];
+
+  const stars = useMemo(() => generateStars(80), []);
+
   return (
     <>
+      {/* Dawn glow overlay */}
+      <div className="time-dawn-glow" />
+
+      {/* Night stars */}
+      <div className="time-stars">
+        {stars.map((star) => (
+          <div
+            key={star.id}
+            className="time-star"
+            style={
+              {
+                left: `${star.x}%`,
+                top: `${star.y}%`,
+                "--tw-duration": `${star.duration}s`,
+                "--tw-delay": `${star.delay}s`,
+              } as React.CSSProperties
+            }
+          />
+        ))}
+      </div>
+
       {/* Surrealist Background Images */}
-      <div className="pointer-events-none absolute inset-0 opacity-14 sm:opacity-20">
+      <div
+        className={`pointer-events-none absolute inset-0 ${config.imageOpacity} transition-opacity duration-[2s]`}
+      >
         <Image
           src="/images/thekiss.jpg"
           alt=""
           width={1280}
           height={1285}
           loading="lazy"
-          className="absolute right-[-5rem] top-32 h-56 w-56 rounded-full object-cover mix-blend-multiply blur-sm sm:right-0 sm:top-40 sm:h-96 sm:w-96 sm:blur-xs sm:animate-float"
+          className={`absolute right-[-5rem] top-32 h-56 w-56 rounded-full object-cover blur-sm sm:right-0 sm:top-40 sm:h-96 sm:w-96 sm:blur-xs sm:animate-float ${config.imageBlend}`}
         />
         <Image
           src="/images/dali1.webp"
@@ -19,7 +98,7 @@ export default function SurrealistBackground() {
           width={320}
           height={320}
           loading="lazy"
-          className="absolute -left-16 bottom-24 h-44 w-44 rounded-full object-cover mix-blend-multiply blur-sm sm:-left-20 sm:bottom-0 sm:h-80 sm:w-80 sm:blur-xs sm:animate-float"
+          className={`absolute -left-16 bottom-24 h-44 w-44 rounded-full object-cover blur-sm sm:-left-20 sm:bottom-0 sm:h-80 sm:w-80 sm:blur-xs sm:animate-float ${config.imageBlend}`}
           style={{ animationDelay: "-5s" }}
         />
         <Image
@@ -28,22 +107,26 @@ export default function SurrealistBackground() {
           width={512}
           height={512}
           loading="lazy"
-          className="absolute left-1/2 top-[48%] hidden h-[22rem] w-[22rem] -translate-x-1/2 rounded-full object-cover mix-blend-multiply blur-sm sm:left-1/4 sm:top-1/2 sm:block sm:h-128 sm:w-128 sm:translate-x-0 sm:blur-xs sm:animate-float"
+          className={`absolute left-1/2 top-[48%] hidden h-[22rem] w-[22rem] -translate-x-1/2 rounded-full object-cover blur-sm sm:left-1/4 sm:top-1/2 sm:block sm:h-128 sm:w-128 sm:translate-x-0 sm:blur-xs sm:animate-float ${config.imageBlend}`}
           style={{ animationDelay: "-10s" }}
         />
       </div>
 
       {/* Floating Orbs */}
-      <div className="absolute inset-0 opacity-24 sm:opacity-30">
-        <div className="absolute left-0 top-24 h-28 w-28 rounded-full bg-dream-200 blur-2xl sm:left-20 sm:top-20 sm:h-40 sm:w-40 sm:animate-drift"></div>
+      <div
+        className={`absolute inset-0 ${config.orbOpacity} transition-opacity duration-[2s]`}
+      >
         <div
-          className="absolute right-2 top-44 h-36 w-36 rounded-full bg-dream-300 blur-2xl sm:right-20 sm:top-40 sm:h-60 sm:w-60 sm:animate-drift"
+          className={`absolute left-0 top-24 h-28 w-28 rounded-full blur-2xl sm:left-20 sm:top-20 sm:h-40 sm:w-40 sm:animate-drift ${config.orb1}`}
+        />
+        <div
+          className={`absolute right-2 top-44 h-36 w-36 rounded-full blur-2xl sm:right-20 sm:top-40 sm:h-60 sm:w-60 sm:animate-drift ${config.orb2}`}
           style={{ animationDelay: "-5s" }}
-        ></div>
+        />
         <div
-          className="absolute bottom-28 left-1/2 h-28 w-28 -translate-x-1/2 rounded-full bg-dream-400 blur-2xl sm:bottom-20 sm:h-40 sm:w-40 sm:animate-drift"
+          className={`absolute bottom-28 left-1/2 h-28 w-28 -translate-x-1/2 rounded-full blur-2xl sm:bottom-20 sm:h-40 sm:w-40 sm:animate-drift ${config.orb3}`}
           style={{ animationDelay: "-10s" }}
-        ></div>
+        />
       </div>
     </>
   );

--- a/src/context/TimeShiftContext.tsx
+++ b/src/context/TimeShiftContext.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import React, {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { type TimePeriod, useTimeOfDay } from "@/hooks/useTimeOfDay";
+
+interface TimeShiftContextType {
+  period: TimePeriod;
+  hour: number;
+}
+
+const TimeShiftContext = createContext<TimeShiftContextType | undefined>(
+  undefined,
+);
+
+export const useTimeShift = () => {
+  const context = useContext(TimeShiftContext);
+  if (context === undefined) {
+    throw new Error("useTimeShift must be used within a TimeShiftProvider");
+  }
+  return context;
+};
+
+interface TimeShiftProviderProps {
+  children: ReactNode;
+}
+
+export const TimeShiftProvider: React.FC<TimeShiftProviderProps> = ({
+  children,
+}) => {
+  const { period: realPeriod, hour: realHour } = useTimeOfDay();
+
+  const [override, setOverride] = useState<TimePeriod | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const t = params.get("time");
+    if (t && ["dawn", "day", "dusk", "night"].includes(t)) {
+      setOverride(t as TimePeriod);
+    }
+  }, []);
+
+  const period = override ?? realPeriod;
+  const hour = override
+    ? { dawn: 6, day: 12, dusk: 18, night: 22 }[override]
+    : realHour;
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.setAttribute("data-time", period);
+
+    return () => {
+      root.removeAttribute("data-time");
+    };
+  }, [period]);
+
+  const value = useMemo(() => ({ period, hour }), [period, hour]);
+
+  return (
+    <TimeShiftContext.Provider value={value}>
+      {children}
+    </TimeShiftContext.Provider>
+  );
+};

--- a/src/hooks/useTimeOfDay.ts
+++ b/src/hooks/useTimeOfDay.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+export type TimePeriod = "dawn" | "day" | "dusk" | "night";
+
+interface TimeState {
+  period: TimePeriod;
+  hour: number;
+}
+
+function resolvePeriod(hour: number): TimePeriod {
+  if (hour >= 5 && hour < 8) return "dawn";
+  if (hour >= 8 && hour < 18) return "day";
+  if (hour >= 18 && hour < 21) return "dusk";
+  return "night";
+}
+
+export function useTimeOfDay(): TimeState {
+  const [state, setState] = useState<TimeState>(() => {
+    const now = new Date();
+    return { period: resolvePeriod(now.getHours()), hour: now.getHours() };
+  });
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = new Date();
+      const hour = now.getHours();
+      setState({ period: resolvePeriod(hour), hour });
+    }, 60_000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return useMemo(() => state, [state]);
+}

--- a/src/sections/Footer.tsx
+++ b/src/sections/Footer.tsx
@@ -14,8 +14,8 @@ const Footer: React.FC = () => {
   const handleClose = () => setShowEasterEgg(false);
 
   return (
-    <footer className="mt-10 border-t border-white/35 bg-gradient-to-r from-white/75 via-dream-50/80 to-dream-100/70 px-3 py-5 shadow-[0_-10px_28px_-24px_rgba(56,189,248,0.55)] backdrop-blur-xl sm:mt-14 sm:px-4 sm:py-8">
-      <div className="relative mx-auto flex min-h-[7rem] w-full max-w-5xl items-center justify-center overflow-hidden rounded-[1.6rem] border border-white/35 bg-white/38 px-5 py-5 text-center shadow-[0_18px_45px_-34px_rgba(18,49,79,0.55)] sm:min-h-[120px] sm:px-6">
+    <footer className="time-footer mt-10 border-t border-white/35 px-3 py-5 backdrop-blur-xl sm:mt-14 sm:px-4 sm:py-8">
+      <div className="time-surface-card relative mx-auto flex min-h-[7rem] w-full max-w-5xl items-center justify-center overflow-hidden rounded-[1.6rem] border px-5 py-5 text-center shadow-[0_18px_45px_-34px_rgba(18,49,79,0.55)] sm:min-h-[120px] sm:px-6">
         {/* Scattered Surreal Icons */}
         <FloatingIcons />
         <div
@@ -24,8 +24,11 @@ const Footer: React.FC = () => {
         />
         {/* Sparkles icon triggers the easter egg */}
         <motion.button
-          className="absolute bottom-3 right-3 z-10 rounded-full bg-white/55 p-2 text-dream-500 shadow-[0_12px_24px_-18px_rgba(18,49,79,0.65)] transition hover:bg-dream-100 sm:bottom-auto sm:right-auto sm:bg-transparent sm:text-dream-400 sm:shadow-none"
-          style={{ transform: "none" }}
+          className="absolute bottom-3 right-3 z-10 rounded-full bg-white/55 p-2 shadow-[0_12px_24px_-18px_rgba(18,49,79,0.65)] transition hover:bg-dream-100 sm:bottom-auto sm:right-auto sm:bg-transparent sm:shadow-none"
+          style={{
+            transform: "none",
+            color: "var(--time-text-muted)",
+          }}
           whileHover={{ scale: 1.15, rotate: 0 }}
           whileTap={{ scale: 0.95 }}
           onClick={handleClick}
@@ -50,7 +53,10 @@ const Footer: React.FC = () => {
           />
         </motion.button>
 
-        <p className="relative z-20 w-[min(100%,34rem)] px-8 text-sm font-semibold leading-6 text-dream-800 sm:px-0 sm:text-base">
+        <p
+          className="relative z-20 w-[min(100%,34rem)] px-8 text-sm font-semibold leading-6 sm:px-0 sm:text-base"
+          style={{ color: "var(--time-text)" }}
+        >
           Capturando momentos en el paisaje onírico del tiempo
         </p>
       </div>

--- a/src/sections/Header.tsx
+++ b/src/sections/Header.tsx
@@ -6,11 +6,18 @@ import type React from "react";
 
 const Header: React.FC = () => {
   return (
-    <header className="sticky top-0 z-20 overflow-hidden border-b border-white/45 bg-white/32 px-3 py-3 backdrop-blur-xl sm:px-4 sm:py-4">
+    <header className="time-header sticky top-0 z-20 overflow-hidden border-b border-white/45 px-3 py-3 backdrop-blur-xl sm:px-4 sm:py-4">
       <div className="mx-auto flex w-full max-w-5xl items-center justify-center">
-        <div className="relative flex min-h-[4.5rem] w-full items-center justify-center overflow-hidden rounded-[1.75rem] border border-white/35 bg-gradient-to-r from-white/45 via-white/15 to-dream-100/35 px-5 py-4 shadow-[0_16px_40px_-32px_rgba(18,49,79,0.65)] sm:min-h-[5.25rem] sm:px-8">
+        <div
+          className="time-surface-card relative flex min-h-[4.5rem] w-full items-center justify-center overflow-hidden rounded-[1.75rem] border px-5 py-4 shadow-[0_16px_40px_-32px_rgba(18,49,79,0.65)] sm:min-h-[5.25rem] sm:px-8"
+          style={{
+            background:
+              "linear-gradient(to right, rgba(255,255,255,0.45), rgba(255,255,255,0.15), var(--time-glow))",
+          }}
+        >
           <motion.div
-            className="absolute right-4 top-2 text-dream-500/80 sm:right-8 sm:top-3"
+            className="absolute right-4 top-2 sm:right-8 sm:top-3"
+            style={{ color: "var(--time-glow)" }}
             animate={{
               y: [0, -10, 0],
               rotate: [0, 5, 0],
@@ -25,7 +32,8 @@ const Header: React.FC = () => {
           </motion.div>
 
           <motion.div
-            className="absolute bottom-2 left-4 text-dream-300/85 sm:left-8"
+            className="absolute bottom-2 left-4 opacity-70 sm:left-8"
+            style={{ color: "var(--time-orb-2)" }}
             animate={{
               x: [0, 10, 0],
               y: [0, 5, 0],
@@ -40,7 +48,8 @@ const Header: React.FC = () => {
           </motion.div>
 
           <motion.div
-            className="absolute left-6 top-3 hidden text-dream-500/80 sm:block"
+            className="absolute left-6 top-3 hidden sm:block"
+            style={{ color: "var(--time-orb-1)" }}
             animate={{
               scale: [1, 1.2, 1],
               opacity: [0.5, 1, 0.5],
@@ -55,10 +64,16 @@ const Header: React.FC = () => {
           </motion.div>
 
           <div className="relative z-10 flex flex-col items-center gap-1 text-center">
-            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] text-dream-600/85 sm:text-[0.72rem]">
+            <p
+              className="text-[0.68rem] font-semibold uppercase tracking-[0.28em] opacity-70 sm:text-[0.72rem]"
+              style={{ color: "var(--time-text-muted)" }}
+            >
               Archivo onírico semanal
             </p>
-            <h1 className="text-balance text-[1.85rem] font-serif italic leading-none tracking-tight text-dream-900 sm:text-4xl md:text-5xl">
+            <h1
+              className="text-balance text-[1.85rem] font-serif italic leading-none tracking-tight sm:text-4xl md:text-5xl"
+              style={{ color: "var(--time-text)" }}
+            >
               Cualidades de Landa
             </h1>
           </div>


### PR DESCRIPTION
Adds automatic dawn/day/dusk/night theme shifting based on the user's local time.

**Changes:**
- `useTimeOfDay` hook that resolves the current time period from the real clock
- `TimeShiftProvider` context with `?time=` query param override for testing
- CSS variable system for four periods: dawn (warm amber), day (current default), dusk (purple/indigo), night (dark with stars)
- `SurrealistBackground` adapts orb colors and image blend modes per period
- `QualityCard` uses period-specific glow colors
- `Header` and `Footer` use time-aware CSS classes
- Night mode adds a twinkling star layer; dawn mode adds a warm glow overlay
- All transitions are smooth (1.8s ease) to feel organic